### PR TITLE
Feature -- Create Missing Artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,32 @@ It can help to create a new script entry in `package.json` so that you can easil
 }
 ```
 
+##### Another Use Case
+
+Some of our contract projects use ZeppelinOS. While ZOS has many upsides (easily upgradeable contracts being a huge one, guards against destroying deployed memory addresses, etc) we've found the need to manually copy over contract addresses both in development and on testnets/mainnet.
+
+The `apply-registry` tool will generate new artifacts in the output artifacts directory even if there are no input artifacts. The workflow for this is as follows:
+
+1. Deploy contracts using ZOS to local ganache, ropsten, etc.
+
+2. Manually copy the deployed contract names and addresses to a new networks file in our dapp directory. For instance, the networks file: `./networks/3.json` would have entries as such (where the lowest entry address **'0xae399886...'** is the most recent deployed version):
+
+  ```javascript
+  [
+    {
+      "contractName": "SimpleToken",
+      "address": "0x8f0483125fcb9aaaefa9209d8e9d7b9c8b9fb90f"
+    },
+    {
+      "contractName": "SimpleToken",
+      "address": "0xae39986e9876c91a936adfae8b6a98e764aeeb7a"
+    }
+  ]
+  ```
+
+3. Run `apply-registry` and it will generate the SimpleToken.json artifact in **'./build/contracts'**, ready for the dapp to use.
+4. To get the ABI, use npm or yarn's `link` command. Or, if the contracts are published on npm simply add the contracts package to your `package.json` and install.
+
 ### 3. Retrieving Entries
 
 You can retrieve the last entry by contract name using the `findLastByContractName(networkId, contractName)` function.

--- a/lib/__tests__/processAllArtifacts.test.js
+++ b/lib/__tests__/processAllArtifacts.test.js
@@ -36,7 +36,7 @@ describe('processAllArtifacts()', () => {
     fs.rmdirSync(outputArtifactsPath)
   })
 
-  it('should do nothing when the input directory does not exist', async () => {
+  it('should ignore the input directory if it does not exist', async () => {
     await processAllArtifacts('asdf', outputArtifactsPath, networksPath)
   })
 

--- a/lib/__tests__/processAllArtifacts.test.js
+++ b/lib/__tests__/processAllArtifacts.test.js
@@ -37,14 +37,10 @@ describe('processAllArtifacts()', () => {
   })
 
   it('should do nothing when the input directory does not exist', async () => {
-    console.log('should do fuck all')
-
     await processAllArtifacts('asdf', outputArtifactsPath, networksPath)
   })
 
   it('should create the output directory when it does not exist', async () => {
-    console.log('should create the output')
-
     const tmpDir = path.join(process.cwd(), 'tmp')
 
     // delete directory and it's files

--- a/lib/__tests__/processAllArtifacts.test.js
+++ b/lib/__tests__/processAllArtifacts.test.js
@@ -11,8 +11,10 @@ var readFile = util.promisify(fs.readFile)
 var rimrafPromisified = util.promisify(rimraf)
 
 describe('processAllArtifacts()', () => {
-  let outputArtifactsPath
-  let destinationFilePath
+  let outputArtifactsPath,
+    destinationFile1Path,
+    destinationFile2Path,
+    destinationFile3Path
 
   const networksPath = path.join(process.cwd(), 'lib', '__stubs__', 'networks')
   const inputArtifactsPath = path.join(process.cwd(), 'lib', '__stubs__', 'artifacts')
@@ -21,10 +23,12 @@ describe('processAllArtifacts()', () => {
 
   beforeAll(async () => {
     outputArtifactsPath = mkdirTmp()
-    destinationFilePath = path.join(outputArtifactsPath, 'Contract2.json')
+    destinationFile1Path = path.join(outputArtifactsPath, 'Contract1.json')
+    destinationFile2Path = path.join(outputArtifactsPath, 'Contract2.json')
+    destinationFile3Path = path.join(outputArtifactsPath, 'Contract3.json')
 
-    await fs.copyFile(sourceFilePath, destinationFilePath, (error) => {
-      console.log('Copying "' + sourceFilePath + '" to: "' + destinationFilePath + '"' )
+    fs.copyFileSync(sourceFilePath, destinationFile2Path, (error) => {
+      console.log('Copying "' + sourceFilePath + '" to: "' + destinationFile2Path + '"' )
 
       if (error) {
         console.error(error)
@@ -57,7 +61,32 @@ describe('processAllArtifacts()', () => {
   it('should process the artifacts', async () => {
     await processAllArtifacts(inputArtifactsPath, outputArtifactsPath, networksPath)
 
-    const json = await readFile(destinationFilePath)
+    await expectFile2ToBeUpdated()
+
+    await expectFile1ToBeCreated()
+    await expectFile3ToBeCreated()
+  })
+
+  async function expectFile1ToBeCreated() {
+    const json = await readFile(destinationFile1Path)
+
+    expect(JSON.parse(json)).toEqual(
+      {
+        'contractName': 'Contract1',
+        'networks': {
+          '2': {
+            'address': '0x5555',
+            'events': {},
+            'links': {},
+            'transactionHash': ''
+          }
+        }
+      }
+    )
+  }
+
+  async function expectFile2ToBeUpdated() {
+    const json = await readFile(destinationFile2Path)
 
     expect(JSON.parse(json)).toEqual(
       {
@@ -86,5 +115,23 @@ describe('processAllArtifacts()', () => {
         'updatedAt': '2018-09-19T21:37:52.903Z'
       }
     )
-  })
+  }
+
+  async function expectFile3ToBeCreated() {
+    const json = await readFile(destinationFile3Path)
+
+    expect(JSON.parse(json)).toEqual(
+      {
+        'contractName': 'Contract3',
+        'networks': {
+          '2': {
+            'address': '0x3333',
+            'events': {},
+            'links': {},
+            'transactionHash': ''
+          }
+        }
+      }
+    )
+  }
 })

--- a/lib/__tests__/uniqueContractNames.test.js
+++ b/lib/__tests__/uniqueContractNames.test.js
@@ -1,0 +1,25 @@
+var uniqueContractNames = require('../uniqueContractNames')
+
+describe('uniqueContractNames()', () => {
+  it('should return a uniq array', async () => {
+
+    const networkConfigs = {
+      '2': [
+        { contractName: 'Contract1', address: '0x1111' },
+        { contractName: 'Contract2', address: '0x2222' },
+        { contractName: 'Contract3', address: '0x3333' },
+        { contractName: 'Contract2', address: '0x4444' },
+        { contractName: 'Contract1', address: '0x5555' }
+      ],
+      '3': [
+        { contractName: 'Contract2', address: 'addy' }
+      ]
+    }
+
+    const uniqArray = await uniqueContractNames(networkConfigs)
+
+    expect(uniqArray).toEqual([
+      'Contract1', 'Contract2', 'Contract3'
+    ])
+  })
+})

--- a/lib/processAllArtifacts.js
+++ b/lib/processAllArtifacts.js
@@ -15,22 +15,19 @@ var readdir = util.promisify(fs.readdir)
 
 const updateArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
   return new Promise(async (resolve, reject) => {
-    await readdir(inputArtifactsPath).then(async (filenames) => {
-      await Promise.all(filenames.map((filename) => {
+    await readdir(inputArtifactsPath).then(async filenames => {
+      await Promise.all(filenames.map(async filename => {
         const filepath = path.join(inputArtifactsPath, filename)
+        const json = fs.readFileSync(filepath)
+        const artifact = JSON.parse(json)
 
-        return readFile(filepath).then(json => {
-          const artifact = JSON.parse(json)
+        const updatedArtifact = await updateArtifact(artifact, networkConfigs)
 
-          return updateArtifact(artifact, networkConfigs).then(updatedArtifact => {
-            const artifactOutputPath = path.join(outputArtifactsPath, filename)
-            const outputJSON = JSON.stringify(updatedArtifact, null, 2)
+        const artifactOutputPath = path.join(outputArtifactsPath, filename)
+        const outputJSON = JSON.stringify(updatedArtifact, null, 2)
+        fs.writeFileSync(artifactOutputPath, outputJSON)
 
-            return writeFile(artifactOutputPath, outputJSON).then(() => {
-              console.log(chalk.cyan(`Updated existing artifact: ${filename}`))
-            })
-          })
-        })
+        console.log(chalk.cyan(`Updated existing artifact: ${filename}`))
       }))
 
       console.log(chalk.grey('Updating complete!'))

--- a/lib/processAllArtifacts.js
+++ b/lib/processAllArtifacts.js
@@ -41,32 +41,19 @@ const updateArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkCon
 
 const createMissingArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
   return new Promise(async (resolve, reject) => {
-
     const uniqContractNames = uniqueContractNames(networkConfigs)
 
-    console.log(uniqContractNames)
-
-
-    uniqContractNames.forEach(async contractName => {
-      console.log(contractName)
+    await uniqContractNames.forEach(async contractName => {
+      const artifact = { contractName }
       const filename = `${contractName}.json`
       const filepath = path.join(inputArtifactsPath, filename)
-      console.log(filename)
 
-      console.log(filepath)
-
-      if (!(await exists(filepath))) {
-        // const artifact = JSON.parse(json)
-        console.log('File does not exist, creating ...')
-        const artifact = {}
+      if (!fs.existsSync(filepath)) {
         const updatedArtifact = await updateArtifact(artifact, networkConfigs)
 
         const artifactOutputPath = path.join(outputArtifactsPath, filename)
         const outputJSON = JSON.stringify(updatedArtifact, null, 2)
-
-        console.log(outputJSON)
-
-        const result = await writeFile(artifactOutputPath, outputJSON)
+        fs.writeFileSync(artifactOutputPath, outputJSON)
 
         console.log(chalk.cyan(`Created new artifact: ${filename}`))
       }
@@ -100,12 +87,6 @@ module.exports = async function (inputArtifactsPath, outputArtifactsPath, networ
     console.log(chalk.green('Updating existing artifacts ...'))
 
     await updateArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
-
-    console.log('resolved')
-
     await createMissingArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
-
-    console.log('end')
-
   }
 }

--- a/lib/processAllArtifacts.js
+++ b/lib/processAllArtifacts.js
@@ -39,14 +39,14 @@ const updateArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkCon
   })
 }
 
-const createMissingArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
+const createMissingArtifactFiles = (outputArtifactsPath, networkConfigs) => {
   return new Promise(async (resolve, reject) => {
     const uniqContractNames = uniqueContractNames(networkConfigs)
 
     await uniqContractNames.forEach(async contractName => {
       const artifact = { contractName }
       const filename = `${contractName}.json`
-      const filepath = path.join(inputArtifactsPath, filename)
+      const filepath = path.join(outputArtifactsPath, filename)
 
       if (!fs.existsSync(filepath)) {
         const updatedArtifact = await updateArtifact(artifact, networkConfigs)
@@ -84,9 +84,12 @@ module.exports = async function (inputArtifactsPath, outputArtifactsPath, networ
   if (networkConfigsIsEmpty) {
     console.log(chalk.red('Network configs are empty, doing nothing ...'))
   } else {
-    console.log(chalk.green('Updating existing artifacts ...'))
+    if (fs.existsSync(inputArtifactsPath)) {
+      console.log(chalk.green('Updating existing artifacts ...'))
+      await updateArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
+    }
 
-    await updateArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
-    await createMissingArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
+    console.log(chalk.green('Creating new artifacts (if necessary) ...'))
+    await createMissingArtifactFiles(outputArtifactsPath, networkConfigs)
   }
 }

--- a/lib/processAllArtifacts.js
+++ b/lib/processAllArtifacts.js
@@ -13,52 +13,46 @@ var readFile = util.promisify(fs.readFile)
 var writeFile = util.promisify(fs.writeFile)
 var readdir = util.promisify(fs.readdir)
 
-const updateArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
-  return new Promise(async (resolve, reject) => {
-    await readdir(inputArtifactsPath).then(async filenames => {
-      await Promise.all(filenames.map(async filename => {
-        const filepath = path.join(inputArtifactsPath, filename)
-        const json = fs.readFileSync(filepath)
-        const artifact = JSON.parse(json)
+const updateArtifactFiles = async (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
+  await readdir(inputArtifactsPath).then(async filenames => {
+    await Promise.all(filenames.map(async filename => {
+      const filepath = path.join(inputArtifactsPath, filename)
+      const json = fs.readFileSync(filepath)
+      const artifact = JSON.parse(json)
 
-        const updatedArtifact = await updateArtifact(artifact, networkConfigs)
+      const updatedArtifact = await updateArtifact(artifact, networkConfigs)
 
-        const artifactOutputPath = path.join(outputArtifactsPath, filename)
-        const outputJSON = JSON.stringify(updatedArtifact, null, 2)
-        fs.writeFileSync(artifactOutputPath, outputJSON)
+      const artifactOutputPath = path.join(outputArtifactsPath, filename)
+      const outputJSON = JSON.stringify(updatedArtifact, null, 2)
+      fs.writeFileSync(artifactOutputPath, outputJSON)
 
-        console.log(chalk.cyan(`Updated existing artifact: ${filename}`))
-      }))
+      console.log(chalk.cyan(`Updated existing artifact: ${filename}`))
+    }))
 
-      console.log(chalk.grey('Updating complete!'))
-      resolve()
-    })
+    console.log(chalk.grey('Updating complete!'))
   })
 }
 
-const createMissingArtifactFiles = (outputArtifactsPath, networkConfigs) => {
-  return new Promise(async (resolve, reject) => {
-    const uniqContractNames = uniqueContractNames(networkConfigs)
+const createMissingArtifactFiles = async (outputArtifactsPath, networkConfigs) => {
+  const uniqContractNames = uniqueContractNames(networkConfigs)
 
-    await uniqContractNames.forEach(async contractName => {
-      const artifact = { contractName }
-      const filename = `${contractName}.json`
-      const filepath = path.join(outputArtifactsPath, filename)
+  await uniqContractNames.forEach(async contractName => {
+    const artifact = { contractName }
+    const filename = `${contractName}.json`
+    const filepath = path.join(outputArtifactsPath, filename)
 
-      if (!fs.existsSync(filepath)) {
-        const updatedArtifact = await updateArtifact(artifact, networkConfigs)
+    if (!fs.existsSync(filepath)) {
+      const updatedArtifact = await updateArtifact(artifact, networkConfigs)
 
-        const artifactOutputPath = path.join(outputArtifactsPath, filename)
-        const outputJSON = JSON.stringify(updatedArtifact, null, 2)
-        fs.writeFileSync(artifactOutputPath, outputJSON)
+      const artifactOutputPath = path.join(outputArtifactsPath, filename)
+      const outputJSON = JSON.stringify(updatedArtifact, null, 2)
+      fs.writeFileSync(artifactOutputPath, outputJSON)
 
-        console.log(chalk.cyan(`Created new artifact: ${filename}`))
-      }
-    })
-
-    console.log(chalk.grey('Creation complete!'))
-    resolve()
+      console.log(chalk.cyan(`Created new artifact: ${filename}`))
+    }
   })
+
+  console.log(chalk.grey('Creation complete!'))
 }
 
 module.exports = async function (inputArtifactsPath, outputArtifactsPath, networksPath) {

--- a/lib/processAllArtifacts.js
+++ b/lib/processAllArtifacts.js
@@ -3,6 +3,7 @@ var util = require('util')
 var fs = require('fs')
 var path = require('path')
 
+var uniqueContractNames = require('./uniqueContractNames')
 var readAllNetworkConfigs = require('./readAllNetworkConfigs')
 var updateArtifact = require('./updateArtifact')
 
@@ -12,34 +13,8 @@ var readFile = util.promisify(fs.readFile)
 var writeFile = util.promisify(fs.writeFile)
 var readdir = util.promisify(fs.readdir)
 
-module.exports = async function (inputArtifactsPath, outputArtifactsPath, networksPath) {
-  let inputDirError = false
-
-  const networkConfigs = await readAllNetworkConfigs(networksPath)
-
-  if (!(await exists(inputArtifactsPath))) {
-    console.log(chalk.red(`Input path: ${inputArtifactsPath} does not exist!`))
-    inputDirError = true
-  }
-
-  console.log('outputArtifactsPath', outputArtifactsPath)
-  if (!(await exists(outputArtifactsPath))) {
-    console.log(chalk.green(`Output path: ${outputArtifactsPath} does not exist. Creating...`))
-    mkdirp.sync(outputArtifactsPath)
-  } else {
-    console.log("ALREADY EXISTS")
-  }
-
-  const networkConfigsIsEmpty = (
-    Object.keys(networkConfigs).length === 0
-      && networkConfigs.constructor === Object
-  )
-
-  if (networkConfigsIsEmpty) {
-    console.log(chalk.red('Network configs are empty, doing nothing ...'))
-  } else if (!inputDirError) {
-    console.log(chalk.green('Processing artifacts ...'))
-
+const updateArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
+  return new Promise(async (resolve, reject) => {
     await readdir(inputArtifactsPath).then(async (filenames) => {
       await Promise.all(filenames.map((filename) => {
         const filepath = path.join(inputArtifactsPath, filename)
@@ -52,13 +27,85 @@ module.exports = async function (inputArtifactsPath, outputArtifactsPath, networ
             const outputJSON = JSON.stringify(updatedArtifact, null, 2)
 
             return writeFile(artifactOutputPath, outputJSON).then(() => {
-              console.log(chalk.cyan(`Updated 'networks' in artifact: ${filename}`))
+              console.log(chalk.cyan(`Updated existing artifact: ${filename}`))
             })
           })
         })
       }))
 
-      console.log(chalk.grey('Complete!'))
+      console.log(chalk.grey('Updating complete!'))
+      resolve()
     })
+  })
+}
+
+const createMissingArtifactFiles = (inputArtifactsPath, outputArtifactsPath, networkConfigs) => {
+  return new Promise(async (resolve, reject) => {
+
+    const uniqContractNames = uniqueContractNames(networkConfigs)
+
+    console.log(uniqContractNames)
+
+
+    uniqContractNames.forEach(async contractName => {
+      console.log(contractName)
+      const filename = `${contractName}.json`
+      const filepath = path.join(inputArtifactsPath, filename)
+      console.log(filename)
+
+      console.log(filepath)
+
+      if (!(await exists(filepath))) {
+        // const artifact = JSON.parse(json)
+        console.log('File does not exist, creating ...')
+        const artifact = {}
+        const updatedArtifact = await updateArtifact(artifact, networkConfigs)
+
+        const artifactOutputPath = path.join(outputArtifactsPath, filename)
+        const outputJSON = JSON.stringify(updatedArtifact, null, 2)
+
+        console.log(outputJSON)
+
+        const result = await writeFile(artifactOutputPath, outputJSON)
+
+        console.log(chalk.cyan(`Created new artifact: ${filename}`))
+      }
+    })
+
+    console.log(chalk.grey('Creation complete!'))
+    resolve()
+  })
+}
+
+module.exports = async function (inputArtifactsPath, outputArtifactsPath, networksPath) {
+  const networkConfigs = await readAllNetworkConfigs(networksPath)
+
+  if (!(await exists(inputArtifactsPath))) {
+    console.log(chalk.yellow(`Input path: ${inputArtifactsPath} does not exist!`))
+  }
+
+  if (!(await exists(outputArtifactsPath))) {
+    console.log(chalk.green(`Output path: ${outputArtifactsPath} does not exist. Creating...`))
+    mkdirp.sync(outputArtifactsPath)
+  }
+
+  const networkConfigsIsEmpty = (
+    Object.keys(networkConfigs).length === 0
+      && networkConfigs.constructor === Object
+  )
+
+  if (networkConfigsIsEmpty) {
+    console.log(chalk.red('Network configs are empty, doing nothing ...'))
+  } else {
+    console.log(chalk.green('Updating existing artifacts ...'))
+
+    await updateArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
+
+    console.log('resolved')
+
+    await createMissingArtifactFiles(inputArtifactsPath, outputArtifactsPath, networkConfigs)
+
+    console.log('end')
+
   }
 }

--- a/lib/uniqueContractNames.js
+++ b/lib/uniqueContractNames.js
@@ -1,0 +1,31 @@
+// uniqueContractNames(networkConfigs)
+//
+// Takes the result of readAllNetworkConfigs (as the passed in param
+// networkConfigs) and returns a unique array of all of the contract names inspect
+// from all of the network files.
+//
+// Example return:
+// [
+//   'Migrations',
+//   'SimpleToken'
+// ]
+//
+module.exports = function (networkConfigs) {
+  let contractNames = []
+
+  for (let networkId in networkConfigs) {
+    const networkConfig = networkConfigs[networkId]
+
+    for (let i = networkConfig.length - 1; i >= 0; i--) {
+      const entry = networkConfig[i]
+
+      contractNames.push(
+        entry.contractName
+      )
+    }
+  }
+
+  return contractNames.filter(
+    (value, index, array) => (array.indexOf(value) === index)
+  )
+}


### PR DESCRIPTION
This will generate any artifact files in the output artifacts directory which did not exist in the input artifacts directory.

For instance, if the input directory has a **'Migrations.json'** artifact, and a networks file has contract addresses for **'Migrations'** and **'SimpleToken'**, then the output artifact directory will have both artifacts for **'Migrations'** and **'SimpleToken'**.

This is useful when you manually add contract addresses (possibly which others have deployed to testnets, mainnets, etc) to a networks file and want to consume addresses in the artifacts files.